### PR TITLE
Setting up the testing infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+*.class
+*.log
+*.swp
+
+# sbt specific
+.cache
+.history
+.lib/
+dist/*
+target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+
+# Scala-IDE specific
+.scala_dependencies
+.worksheet
+.idea
+
+# ENSIME specific
+.ensime_cache/
+.ensime
+
+.bloop/
+.bsp/
+.metals/
+.vscode/
+metals.sbt

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Language Features a la carte
+
+A tool checking that some specific language features are not used

--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,49 @@
+import Dependencies._
+import sbtbuildinfo.BuildInfoPlugin
+
+lazy val semantic = project
+  .in(file("semantic"))
+  .settings(
+    moduleName := "semantic",
+  )
+
+lazy val syntactic = project
+  .in(file("syntactic"))
+  .settings(
+    moduleName := "syntactic",
+    libraryDependencies ++= Seq(
+      scalameta
+    )
+  )
+
+lazy val testsShared = project
+  .in(file("tests/shared"))
+
+lazy val testsInput = project
+  .in(file("tests/input"))
+
+lazy val testsOutput = project
+  .in(file("tests/output"))
+  .dependsOn(syntactic)
+
+lazy val testsUnit = project
+  .in(file("tests/unit"))
+  .settings(
+    buildInfoPackage := "tests",
+    buildInfoObject := "BuildInfo",
+    libraryDependencies ++= Seq(
+      scalatest,
+      funsuite,
+      scalametaTeskit
+    ),
+    Compile / compile / compileInputs := {
+      (Compile / compile / compileInputs)
+        .dependsOn(
+          testsShared / Compile / compile,
+          testsInput / Compile / compile
+        )
+        .value
+    }
+  )
+  .enablePlugins(BuildInfoPlugin)
+  .dependsOn(syntactic, testsOutput)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,0 +1,16 @@
+import sbt._
+
+object Dependencies {
+  val scalatestVersion = "3.0.8"
+  val scalametaVersion = "4.4.34"
+  val junitInterfaceVersion = "0.11"
+  val junitVersion = "4.13.2"
+  val funsuiteVersion = "3.2.11"
+
+  val scalatest = "org.scalatest" %% "scalatest" % scalatestVersion
+  val scalameta = "org.scalameta" %% "scalameta" % scalametaVersion
+  val scalametaTeskit = "org.scalameta" %% "testkit" % scalametaVersion % Test
+  val junitInterface = "com.novocode" %% "junit-interface" % junitInterfaceVersion % Test
+  val junit = "junit" %% "junit" % junitVersion % Test
+  val funsuite = "org.scalatest" %% "scalatest-funsuite" % funsuiteVersion  % "test"
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.6.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.10.0")

--- a/syntactic/src/main/scala/Checker.scala
+++ b/syntactic/src/main/scala/Checker.scala
@@ -1,0 +1,64 @@
+package syntactic
+
+import Rule._
+
+import java.io.File
+import scala.meta._
+import scala.util.{Try, Using}
+
+/**
+ * @param rules rules to be checked
+ */
+class Checker(rules: List[Rule]) {
+  require(rules.nonEmpty, "checker must have at least 1 rule")
+
+  // matches trees that do not match any rule
+  private val defaultPartFunc: PartialFunction[Tree, Option[Violation]] = {
+    case _ => None
+  }
+
+  private val combinedCheckFunc = {
+    val checkFuncs = rules.map(_.checkFunc.andThen(Some(_)))
+    checkFuncs.tail
+      .foldLeft[PartialFunction[Tree, Option[Violation]]](checkFuncs.head)(_.orElse(_))
+      .orElse(defaultPartFunc)
+  }
+
+  /**
+   * Apply the rules to the input program
+   * @param source input program
+   * @return a list of the violations of the checker rules
+   */
+  def check(source: Source): List[Violation] = {
+    source.collect(combinedCheckFunc).flatten
+  }
+
+  /**
+   * Parses the input program and applies the rules to it
+   * @param sourceCode program to parse and check
+   * @return a list of the violations of the checker rules
+   */
+  def check(sourceCode: String): Try[List[Violation]] = Try {
+    val source = sourceCode.parse[Source].get
+    check(source)
+  }
+
+  /**
+   * Loads the program from the file described by the given name and applies the rules to it
+   * @param filename name/path of the file to be checked
+   * @return a list of the violations of the checker rules
+   */
+  def checkFile(filename: String): Try[List[Violation]] = {
+    val content = Using(scala.io.Source.fromFile(filename)) { bufferedSource =>
+      bufferedSource.getLines().mkString
+    }
+    content.flatMap(check)
+  }
+
+}
+
+object Checker {
+
+  def apply(rule: Rule, rules: Rule*): Checker = new Checker(rule :: rules.toList)
+
+}

--- a/syntactic/src/main/scala/Rules.scala
+++ b/syntactic/src/main/scala/Rules.scala
@@ -1,0 +1,59 @@
+package syntactic
+
+import scala.meta._
+
+/**
+ * Specification of language constructs that are forbidden
+ * @param checkFunc PartialFunction reporting the forbidden constructs
+ * @param msg explanation of why the construct is rejected
+ */
+sealed abstract class Rule(val checkFunc: PartialFunction[Tree, Rule.Violation], val msg: String)
+
+object Rule {
+
+  /**
+   * Forbid the use of null
+   */
+  case object NoNull extends Rule({
+    case nullKw: Lit.Null => reportNull(nullKw)
+  }, "usage of null is forbidden")
+  private def reportNull(kw: Tree) = Violation(kw, NoNull)
+
+  /**
+   * Forbid casts with asInstanceOf
+   */
+  case object NoCast extends Rule({
+    case asInstanceOfKw @ Name("asInstanceOf") => reportCast(asInstanceOfKw)
+  }, "casts are forbidden")
+  private def reportCast(kw: Tree) = Violation(kw, NoCast)
+
+  /**
+   * Forbid the use of var
+   */
+  case object NoVar extends Rule({
+    case varKw: Defn.Var => reportVar(varKw)
+    case varKw: Decl.Var => reportVar(varKw)
+  }, "usage of var is forbidden")
+  private def reportVar(kw: Tree) = Violation(kw, NoVar)
+
+  /**
+   * Forbid the use of imperative loops (while and do-while)
+   */
+  case object NoWhile extends Rule({
+    case whileKw: Term.While => reportImperativeLoop(whileKw)
+    case doWhileKw: Term.Do => reportImperativeLoop(doWhileKw)
+  }, "usage of while and do-while loops is forbidden")
+  private def reportImperativeLoop(kw: Tree) = Violation(kw, NoWhile)
+
+  /**
+   * Violation of a rule
+   * @param forbiddenNode node that violates the rule
+   * @param violatedRule rule that rejected this node
+   */
+  case class Violation(val forbiddenNode: Tree, val violatedRule: Rule){
+    val pos: Position = forbiddenNode.pos
+
+    override def toString: String = s"${pos.startLine}:${pos.startColumn}: ${violatedRule.msg}"
+  }
+
+}

--- a/tests/input/src/main/scala/example/Example.scala
+++ b/tests/input/src/main/scala/example/Example.scala
@@ -1,0 +1,34 @@
+
+abstract class Example {
+  private var w: Int = 0
+  var y: Int
+  val z: String
+
+  def f(x: Int, y: Int): Int = 2*x+y+x*x*x
+
+  def foo(str: String, bar: Option[String]): String = {
+    if (str.length > 5){
+      bar match {
+        case Some(value) => value ++ str ++ s"${null}"
+        case None => if (str.length < 10) str else null
+      }
+    }
+    else {
+      var x = 0
+      while (x < 1000){
+        x = x + (2*x-5) % 15
+        y = 2
+        while (y > -50){
+          y = y - 1
+          val p = null
+          y = y + p.asInstanceOf[Int]
+        }
+      }
+      do {
+        y = y + 5
+      } while (y < 0)
+      y.toString
+    }
+  }
+
+}

--- a/tests/output/src/main/scala/example/NoNullNoCastOutput.scala
+++ b/tests/output/src/main/scala/example/NoNullNoCastOutput.scala
@@ -1,0 +1,15 @@
+package output.example
+
+import syntactic.Checker
+import syntactic.Rule
+
+object NoNullNoCastOutput extends Output (
+
+  Checker(Rule.NoNull, Rule.NoCast),
+  List(
+    (11, 48),
+    (12, 51),
+    (22, 18),
+    (23, 20)
+  )
+)

--- a/tests/output/src/main/scala/example/NoVarNoWhileOutput.scala
+++ b/tests/output/src/main/scala/example/NoVarNoWhileOutput.scala
@@ -1,0 +1,17 @@
+package output.example
+
+import syntactic.Checker
+import syntactic.Rule
+
+object NoVarNoWhileOutput extends Output (
+
+  Checker(Rule.NoVar, Rule.NoWhile),
+  List(
+    (2, 2),
+    (3, 2),
+    (16, 6),
+    (17, 6),
+    (20, 8),
+    (26, 6)
+  )
+)

--- a/tests/output/src/main/scala/example/Output.scala
+++ b/tests/output/src/main/scala/example/Output.scala
@@ -1,0 +1,5 @@
+package output.example
+
+import syntactic.Checker
+
+case class Output(checker: Checker, expected: List[(Int, Int)])

--- a/tests/output/src/main/scala/example/package.scala
+++ b/tests/output/src/main/scala/example/package.scala
@@ -1,0 +1,5 @@
+package output
+
+package object example {
+  val outputs = List(NoVarNoWhileOutput, NoNullNoCastOutput)
+}

--- a/tests/unit/src/test/scala/RuleSuite.scala
+++ b/tests/unit/src/test/scala/RuleSuite.scala
@@ -1,0 +1,23 @@
+import scala.meta._
+import scala.meta.internal.io.FileIO
+import scala.meta.io.AbsolutePath
+import java.nio.charset.StandardCharsets
+
+import org.junit.Test
+import org.junit.Assert._
+import org.scalatest.FunSuite
+import org.scalatest.BeforeAndAfter
+
+class RuleSuite extends FunSuite {
+  
+  test("Example test") {
+    val path = AbsolutePath("tests/input/src/main/scala/example/Example.scala")
+    val sourceCode = FileIO.slurp(path, StandardCharsets.UTF_8)
+    import output.example.outputs
+    for (output <- outputs) {
+      println(output)
+      val detectedViolations = output.checker.check(sourceCode).get
+      assertEquals(output.expected, detectedViolations.map(violation => (violation.pos.startLine, violation.pos.startColumn)))
+    }
+  }
+}


### PR DESCRIPTION
The testing infrastructure follows the one in `scalafix`.

The input is scala source code  (or tasty) under the directory `tests/input`. The output under the directory `tests/output` consists of a checker and expected positions of violations, in the format of

```scala
case class Output(checker: Checker, expected: List[(Int, Int)])
```

The unit tests are under the directory `tests/unit`.

I used @ValentinAebi 's code for testing.